### PR TITLE
Fixes issue where Quick Field JS would load in the frontend

### DIFF
--- a/quickfield/QuickFieldPlugin.php
+++ b/quickfield/QuickFieldPlugin.php
@@ -44,7 +44,7 @@ class QuickFieldPlugin extends BasePlugin
 	{
 		parent::init();
 
-		if($this->isCraftRequiredVersion())
+		if(craft()->request->isCpRequest() && $this->isCraftRequiredVersion())
 		{
 			$this->includeResources();
 		}


### PR DESCRIPTION
Adds a test for `craft()->request->isCpRequest()`, preventing Quick Field's JS from loading in the frontend.

Quick Field has no use case outside the CP, so loading its JavaScript in the frontend is redundant. It also causes various JS errors as neither the `Craft` object nor Garnish is available to the frontend (see http://cly.mmikkel.no/3T411p3I0x0Y).
